### PR TITLE
Added Fabric support in the manifest builder 

### DIFF
--- a/modpack-uploader.ps1
+++ b/modpack-uploader.ps1
@@ -123,11 +123,20 @@ function New-ManifestJson {
             }) > $null
     }
 
+    $modloaderId = $minecraftInstanceJson.baseModLoader.name
+
+    if ($MODLOADER -eq "fabric") {
+        # Example output: "fabric-0.13.3-1.18.1"
+        $splitModloaderId = $modloaderId -split "-"
+        # Only keep "fabric-0.13.3"
+        $modloaderId = $splitModloaderId[0] + $splitModloaderId[1]
+    }
+
     $jsonOutput = @{
         minecraft       = @{
             version    = $minecraftInstanceJson.baseModLoader.minecraftVersion
             modLoaders = @(@{
-                    id      = $minecraftInstanceJson.baseModLoader.name
+                    id      = $modloaderId
                     primary = $true
                 })
         }

--- a/settings.ps1
+++ b/settings.ps1
@@ -37,6 +37,11 @@ $MODPACK_VERSION = "1.0.1"
 # Should be "$null" if this is the first release
 $LAST_MODPACK_VERSION = "1.0.0"
 
+# Which modloader the modpack uses
+# Can be "forge" or "fabric"
+# default: "forge"
+$MODLOADER = "forge"
+
 # =====================================================================//
 #  CHANGELOG SETTINGS
 # =====================================================================//


### PR DESCRIPTION
Previously, the manifest builder would put a string like `fabric-0.13.3-1.18.1` as modloader id, but CurseForge expects only `fabric-0.13.3`

This PR adds a `$MODLOADER` setting, when set to `fabric` the last part of the modloader id will be pruned.