### PR TITLE
allows adding a specific file in a folder by creating the folder first in overridesFolder

### DIFF
--- a/modpack-uploader.ps1
+++ b/modpack-uploader.ps1
@@ -94,6 +94,10 @@ function New-ClientFiles {
             Write-Host "Adding " -ForegroundColor Cyan -NoNewline
             Write-Host $_ -ForegroundColor Blue -NoNewline
             Write-Host " to client files." -ForegroundColor Cyan
+            $destinationFolder = "$overridesFolder/$_" | Split-Path
+            if (!(Test-Path -Path $destinationFolder)) {
+                New-Item $destinationFolder -Type Directory
+            }
             Copy-Item -Path $_ -Destination "$overridesFolder/$_" -Recurse
         }
 


### PR DESCRIPTION
allows doing this:

```pwsh
$FOLDERS_TO_INCLUDE_IN_CLIENT_FILES = @(
    "dir/file"
)
```