### PR TITLE
added basic support for adding third party mods to client files

### DIFF
--- a/modpack-uploader.ps1
+++ b/modpack-uploader.ps1
@@ -107,6 +107,17 @@ function New-ClientFiles {
             Copy-Item -Path $_ -Destination "$overridesFolder/$_" -Recurse
         }
 
+        $destinationFolder = "$overridesFolder/mods"
+        if (!(Test-Path -Path $destinationFolder)) {
+            New-Item $destinationFolder -Type Directory
+        }
+        $FILES_TO_INCLUDE_IN_MODS_FOLDER_IN_CLIENT_FILES | ForEach-Object {
+            Write-Host "Adding " -ForegroundColor Cyan -NoNewline
+            Write-Host $_ -ForegroundColor Blue -NoNewline
+            Write-Host " to the mods folder in the client files." -ForegroundColor Cyan
+            Copy-Item -Path $_ -Destination "$overridesFolder/mods/$_" -Recurse
+        }
+
         Remove-BlacklistedFiles
 
         # Zipping up the newly created overrides folder and $manifest
@@ -363,9 +374,9 @@ function New-GitHubRelease {
         };
     
         $Body = @{
-            tag_name         = $MODPACK_VERSION
-            name             = $MODPACK_VERSION
-			generate_release_notes = $true
+            tag_name               = $MODPACK_VERSION
+            name                   = $MODPACK_VERSION
+            generate_release_notes = $true
         } | ConvertTo-Json
 
     

--- a/modpack-uploader.ps1
+++ b/modpack-uploader.ps1
@@ -115,7 +115,7 @@ function New-ClientFiles {
             Write-Host "Adding " -ForegroundColor Cyan -NoNewline
             Write-Host $_ -ForegroundColor Blue -NoNewline
             Write-Host " to the mods folder in the client files." -ForegroundColor Cyan
-            Copy-Item -Path $_ -Destination "$overridesFolder/mods/$_" -Recurse
+            Copy-Item -Path $_ -Destination "$overridesFolder/$_" -Recurse
         }
 
         Remove-BlacklistedFiles

--- a/settings.ps1
+++ b/settings.ps1
@@ -94,6 +94,10 @@ $CONFIGS_TO_REMOVE_FROM_CLIENT_FILES = @()
 
 $FOLDERS_TO_REMOVE_FROM_CLIENT_FILES = @("local/ftbutilities", "resourcepacks")
 
+# Example: 
+# $FILES_TO_INCLUDE_IN_MODS_FOLDER_IN_CLIENT_FILES = @("mods/Apotheosis-1.19.2-6.2.1.jar", "mods/create-1.19.2-0.5.1.b.jar")
+$FILES_TO_INCLUDE_IN_MODS_FOLDER_IN_CLIENT_FILES = @()
+
 #=====================================================================//
 #  SERVER FILE SETTINGS
 #=====================================================================//


### PR DESCRIPTION
Use the new setting `$FILES_TO_INCLUDE_IN_MODS_FOLDER_IN_CLIENT_FILES` in `settings.ps1` to specify files you want copied into the client zip's `overrides/mods` folder.